### PR TITLE
Add option to keep keepAttributableURLs

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,15 +9,12 @@ const {MainThreadTasks} = require('./lib/main-thread-tasks.js');
 function computeMainThreadTasks(trace, options = {}) {
   const {
     flatten = false,
-    keepAttributableURLs = false
   } = options;
   const allTasks = MainThreadTasks.compute(trace);
   const result = [];
   for (const task of allTasks) {
     task.kind = task.group.id;
     delete task.group;
-    if (!keepAttributableURLs)
-      delete task.attributableURLs;
     if (!task.parent || flatten)
       result.push(task);
   }

--- a/index.js
+++ b/index.js
@@ -9,13 +9,15 @@ const {MainThreadTasks} = require('./lib/main-thread-tasks.js');
 function computeMainThreadTasks(trace, options = {}) {
   const {
     flatten = false,
+    keepAttributableURLs = false
   } = options;
   const allTasks = MainThreadTasks.compute(trace);
   const result = [];
   for (const task of allTasks) {
     task.kind = task.group.id;
     delete task.group;
-    delete task.attributableURLs;
+    if (!keepAttributableURLs)
+      delete task.attributableURLs;
     if (!task.parent || flatten)
       result.push(task);
   }


### PR DESCRIPTION
Hi @aslushnikov 
would it be ok to add an option to keep the attributable URL? Thinking it could be good way to keep track of time spent for third party scripts.

Best
Peter