### PR TITLE
Support missing TracingStartedInBrowser

### DIFF
--- a/lib/tracing-processor.js
+++ b/lib/tracing-processor.js
@@ -237,6 +237,25 @@ class TraceProcessor {
       }
     }
 
+    const navStartEvt = events.find(e => Boolean(e.name === 'navigationStart' && e.args && e.args.data && 
+						 e.args.data.isLoadingMainFrame && e.args.data.documentLoaderURL));
+    // Find the first resource that was requested and make sure it agrees on the id.
+    const firstResourceSendEvt = events.find(e => e.name === 'ResourceSendRequest');
+    // We know that these properties exist if we found the events, but TSC doesn't.
+    if (navStartEvt && navStartEvt.args && navStartEvt.args.data &&
+         firstResourceSendEvt &&
+         firstResourceSendEvt.pid === navStartEvt.pid &&
+	firstResourceSendEvt.tid === navStartEvt.tid) {
+	const frameId = navStartEvt.args.frame;
+	if (frameId) {
+	    return {
+		pid: navStartEvt.pid,
+		    tid: navStartEvt.tid,
+		    frameId,
+		    };
+	}
+    }
+
     throw new LHError(LHError.errors.NO_TRACING_STARTED);
   }
 


### PR DESCRIPTION
Backport Lighthouse fix for Chrome 74+.

@patrickhulce is this the fix for TracingStartedInBrowser? Would be great to include it, then I can test and see if I can reproduce #8 easier.

@aslushnikov what about adding prettier? My default settings always mess up the code formatting compared with your defaults :)